### PR TITLE
Refactoring with a MapStore

### DIFF
--- a/front/src/Components/Companion/Companion.svelte
+++ b/front/src/Components/Companion/Companion.svelte
@@ -1,7 +1,6 @@
 <script lang="typescript">
-    import { onDestroy } from "svelte";
-
     import { gameManager } from "../../Phaser/Game/GameManager";
+    import type { PictureStore } from "../../Stores/PictureStore";
 
     export let userId: number;
     export let placeholderSrc: string;
@@ -9,17 +8,23 @@
     export let height: string = "62px";
 
     const gameScene = gameManager.getCurrentGameScene();
-    const playerWokaPictureStore = gameScene.getUserCompanionPictureStore(userId);
-
-    let src = placeholderSrc;
-    const unsubscribe = playerWokaPictureStore.picture.subscribe((source) => {
-        src = source ?? placeholderSrc;
-    });
-
-    onDestroy(unsubscribe);
+    let companionWokaPictureStore: PictureStore | undefined;
+    if (userId === -1) {
+        companionWokaPictureStore = gameScene.CurrentPlayer.companion?.pictureStore;
+    } else {
+        companionWokaPictureStore = gameScene.MapPlayersByKey.getNestedStore(
+            userId,
+            (item) => item.companion?.pictureStore
+        );
+    }
 </script>
 
-<img {src} alt="" class="nes-pointer" style="--theme-width: {width}; --theme-height: {height}" />
+<img
+    src={$companionWokaPictureStore ?? placeholderSrc}
+    alt=""
+    class="nes-pointer"
+    style="--theme-width: {width}; --theme-height: {height}"
+/>
 
 <style>
     img {

--- a/front/src/Components/Woka/Woka.svelte
+++ b/front/src/Components/Woka/Woka.svelte
@@ -2,6 +2,7 @@
     import { onDestroy } from "svelte";
 
     import { gameManager } from "../../Phaser/Game/GameManager";
+    import { playersStore } from "../../Stores/PlayersStore";
 
     export let userId: number;
     export let placeholderSrc: string;
@@ -9,10 +10,16 @@
     export let height: string = "62px";
 
     const gameScene = gameManager.getCurrentGameScene();
-    const playerWokaPictureStore = gameScene.getUserWokaPictureStore(userId);
+    let playerWokaPictureStore;
+    if (userId === -1) {
+        playerWokaPictureStore = gameScene.CurrentPlayer.pictureStore;
+    } else {
+        playerWokaPictureStore = gameScene.MapPlayersByKey.getNestedStore(userId, (item) => item.pictureStore);
+    }
 
     let src = placeholderSrc;
-    const unsubscribe = playerWokaPictureStore.picture.subscribe((source) => {
+
+    const unsubscribe = playerWokaPictureStore.subscribe((source) => {
         src = source ?? placeholderSrc;
     });
 

--- a/front/src/Phaser/Companion/Companion.ts
+++ b/front/src/Phaser/Companion/Companion.ts
@@ -2,6 +2,8 @@ import Sprite = Phaser.GameObjects.Sprite;
 import Container = Phaser.GameObjects.Container;
 import { PlayerAnimationDirections, PlayerAnimationTypes } from "../Player/Animation";
 import { TexturesHelper } from "../Helpers/TexturesHelper";
+import { Writable, writable } from "svelte/store";
+import type { PictureStore } from "../../Stores/PictureStore";
 
 export interface CompanionStatus {
     x: number;
@@ -22,6 +24,7 @@ export class Companion extends Container {
     private companionName: string;
     private direction: PlayerAnimationDirections;
     private animationType: PlayerAnimationTypes;
+    private readonly _pictureStore: Writable<string | undefined>;
 
     constructor(scene: Phaser.Scene, x: number, y: number, name: string, texturePromise: Promise<string>) {
         super(scene, x + 14, y + 4);
@@ -36,11 +39,14 @@ export class Companion extends Container {
         this.animationType = PlayerAnimationTypes.Idle;
 
         this.companionName = name;
+        this._pictureStore = writable(undefined);
 
         texturePromise.then((resource) => {
             this.addResource(resource);
             this.invisible = false;
-            this.emit("texture-loaded");
+            return this.getSnapshot().then((htmlImageElementSrc) => {
+                this._pictureStore.set(htmlImageElementSrc);
+            });
         });
 
         this.scene.physics.world.enableBody(this);
@@ -237,5 +243,9 @@ export class Companion extends Container {
         }
 
         super.destroy();
+    }
+
+    public get pictureStore(): PictureStore {
+        return this._pictureStore;
     }
 }

--- a/front/src/Stores/PictureStore.ts
+++ b/front/src/Stores/PictureStore.ts
@@ -1,0 +1,6 @@
+import type { Readable } from "svelte/store";
+
+/**
+ * A store that contains the player/companion avatar picture
+ */
+export type PictureStore = Readable<string | undefined>;

--- a/front/src/Stores/PlayersStore.ts
+++ b/front/src/Stores/PlayersStore.ts
@@ -12,7 +12,7 @@ let idCount = 0;
 function createPlayersStore() {
     let players = new Map<number, PlayerInterface>();
 
-    const { subscribe, set, update } = writable(players);
+    const { subscribe, set, update } = writable<Map<number, PlayerInterface>>(players);
 
     return {
         subscribe,

--- a/front/src/Stores/UserCompanionPictureStore.ts
+++ b/front/src/Stores/UserCompanionPictureStore.ts
@@ -1,8 +1,0 @@
-import { writable, Writable } from "svelte/store";
-
-/**
- * A store that contains the player companion picture
- */
-export class UserCompanionPictureStore {
-    constructor(public picture: Writable<string | undefined> = writable(undefined)) {}
-}

--- a/front/src/Stores/UserWokaPictureStore.ts
+++ b/front/src/Stores/UserWokaPictureStore.ts
@@ -1,8 +1,0 @@
-import { writable, Writable } from "svelte/store";
-
-/**
- * A store that contains the player avatar picture
- */
-export class UserWokaPictureStore {
-    constructor(public picture: Writable<string | undefined> = writable(undefined)) {}
-}

--- a/front/src/Stores/Utils/MapStore.ts
+++ b/front/src/Stores/Utils/MapStore.ts
@@ -1,0 +1,122 @@
+import type { Readable, Subscriber, Unsubscriber, Writable } from "svelte/store";
+import { get, readable, writable } from "svelte/store";
+
+/**
+ * Is it a Map? Is it a Store? No! It's a MapStore!
+ *
+ * The MapStore behaves just like a regular JS Map, but... it is also a regular Svelte store.
+ *
+ * As a bonus, you can also get a store on any given key of the map.
+ *
+ * For instance:
+ *
+ * const mapStore = new MapStore<string, string>();
+ * mapStore.getStore('foo').subscribe((value) => {
+ *     console.log('Foo key has been written to the store. New value: ', value);
+ * });
+ * mapStore.set('foo', 'bar');
+ *
+ *
+ * Even better, if the items stored in map contain stores, you can directly get the store to those values:
+ *
+ * const mapStore = new MapStore<string, {
+ *     nestedStore: Readable<string>
+ * }>();
+ *
+ * mapStore.getNestedStore('foo', item => item.nestedStore).subscribe((value) => {
+ *     console.log('Foo key has been written to the store or the nested store has been updated. New value: ', value);
+ * });
+ * mapStore.set('foo', {
+ *     nestedStore: writable('bar')
+ * });
+ * // Whenever the nested store is updated OR the 'foo' key is overwritten, the store returned by mapStore.getNestedStore
+ * // will be triggered.
+ */
+export class MapStore<K, V> extends Map<K, V> implements Readable<Map<K, V>> {
+    private readonly store = writable(this);
+    private readonly storesByKey = new Map<K, Writable<V | undefined>>();
+
+    subscribe(run: Subscriber<Map<K, V>>, invalidate?: (value?: Map<K, V>) => void): Unsubscriber {
+        return this.store.subscribe(run, invalidate);
+    }
+
+    clear() {
+        super.clear();
+        this.store.set(this);
+        this.storesByKey.forEach((store) => {
+            store.set(undefined);
+        });
+    }
+
+    delete(key: K): boolean {
+        const result = super.delete(key);
+        if (result) {
+            this.store.set(this);
+            this.storesByKey.get(key)?.set(undefined);
+        }
+        return result;
+    }
+
+    set(key: K, value: V): this {
+        super.set(key, value);
+        this.store.set(this);
+        this.storesByKey.get(key)?.set(value);
+        return this;
+    }
+
+    getStore(key: K): Readable<V | undefined> {
+        const store = writable(this.get(key), () => {
+            return () => {
+                // No more subscribers!
+                this.storesByKey.delete(key);
+            };
+        });
+        this.storesByKey.set(key, store);
+        return store;
+    }
+
+    /**
+     * Returns an "inner" store inside a value stored in the map.
+     */
+    getNestedStore<T>(key: K, accessor: (value: V) => Readable<T> | undefined): Readable<T | undefined> {
+        const initVal = this.get(key);
+        let initStore: Readable<T> | undefined;
+        let initStoreValue: T | undefined;
+        if (initVal) {
+            initStore = accessor(initVal);
+            if (initStore !== undefined) {
+                initStoreValue = get(initStore);
+            }
+        }
+
+        return readable(initStoreValue, (set) => {
+            const storeByKey = this.getStore(key);
+
+            let unsubscribeDeepStore: Unsubscriber | undefined;
+            const unsubscribe = storeByKey.subscribe((newMapValue) => {
+                if (unsubscribeDeepStore) {
+                    unsubscribeDeepStore();
+                }
+                if (newMapValue === undefined) {
+                    set(undefined);
+                } else {
+                    const deepValueStore = accessor(newMapValue);
+                    if (deepValueStore !== undefined) {
+                        set(get(deepValueStore));
+
+                        unsubscribeDeepStore = deepValueStore.subscribe((value) => {
+                            set(value);
+                        });
+                    }
+                }
+            });
+
+            return () => {
+                unsubscribe();
+                if (unsubscribeDeepStore) {
+                    unsubscribeDeepStore();
+                }
+            };
+        });
+    }
+}

--- a/front/tests/Stores/Utils/MapStoreTest.ts
+++ b/front/tests/Stores/Utils/MapStoreTest.ts
@@ -1,0 +1,97 @@
+import "jasmine";
+import {MapStore} from "../../../src/Stores/Utils/MapStore";
+import type {Readable, Writable} from "svelte/store";
+import {get, writable} from "svelte/store";
+
+describe("Main store", () => {
+    it("Set / delete / clear triggers main store updates", () => {
+        const mapStore = new MapStore<string, string>();
+
+        let triggered = false;
+
+        mapStore.subscribe((map) => {
+            triggered = true;
+            expect(map).toBe(mapStore);
+        })
+
+        expect(triggered).toBeTrue();
+        triggered = false;
+        mapStore.set('foo', 'bar');
+        expect(triggered).toBeTrue();
+
+        triggered = false;
+        mapStore.delete('baz');
+        expect(triggered).toBe(false);
+        mapStore.delete('foo');
+        expect(triggered).toBe(true);
+
+        triggered = false;
+        mapStore.clear();
+        expect(triggered).toBe(true);
+    });
+
+    it("generates stores for keys with getStore", () => {
+
+        const mapStore = new MapStore<string, string>();
+
+        let valueReceivedInStoreForFoo: string|undefined;
+        let valueReceivedInStoreForBar: string|undefined;
+
+        mapStore.set('foo', 'someValue');
+
+        mapStore.getStore('foo').subscribe((value) => {
+            valueReceivedInStoreForFoo = value;
+        });
+        const unsubscribeBar = mapStore.getStore('bar').subscribe((value) => {
+            valueReceivedInStoreForBar = value;
+        });
+
+        expect(valueReceivedInStoreForFoo).toBe('someValue');
+        expect(valueReceivedInStoreForBar).toBe(undefined);
+        mapStore.set('foo', 'someOtherValue');
+        expect(valueReceivedInStoreForFoo).toBe('someOtherValue');
+        mapStore.delete('foo');
+        expect(valueReceivedInStoreForFoo).toBe(undefined);
+        mapStore.set('bar', 'baz');
+        expect(valueReceivedInStoreForBar).toBe('baz');
+        mapStore.clear();
+        expect(valueReceivedInStoreForBar).toBe(undefined);
+        unsubscribeBar();
+        mapStore.set('bar', 'fiz');
+        expect(valueReceivedInStoreForBar).toBe(undefined);
+    });
+
+    it("generates stores with getStoreByAccessor", () => {
+        const mapStore = new MapStore<string, {
+            foo: string,
+            store: Writable<string>
+        }>();
+
+        const fooStore = mapStore.getNestedStore('foo', (value) => {
+            return value.store;
+        });
+
+        mapStore.set('foo', {
+            foo: 'bar',
+            store: writable('init')
+        });
+
+        expect(get(fooStore)).toBe('init');
+
+        mapStore.get('foo')?.store.set('newVal');
+
+        expect(get(fooStore)).toBe('newVal');
+
+        mapStore.set('foo', {
+            foo: 'bar',
+            store: writable('anotherVal')
+        });
+
+        expect(get(fooStore)).toBe('anotherVal');
+
+        mapStore.delete('foo');
+
+        expect(get(fooStore)).toBeUndefined();
+
+    });
+});


### PR DESCRIPTION
A great deal of the complexity of the current code is that we must chain
2 reactive values (one in the map "GameScene.MapPlayersByKey" and one in
the snapshot store).

The new generic MapStore class can be used to listen to stores inside a map.
When the store inside the map, or the map itself is modified, the
resulting store is updated.